### PR TITLE
Update issue template hyperlinks in CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -66,7 +66,7 @@ comment to the existing issue if there is extra information you can contribute.
 
 Bugs are tracked as [GitHub issues](https://guides.github.com/features/issues/).
 
-Simply create an issue on the [GitHub Desktop issue tracker](https://github.com/desktop/desktop/issues/new?template=bug_report.md)
+Simply create an issue on the [GitHub Desktop issue tracker](https://github.com/desktop/desktop/issues/new?template=bug_report.yaml)
 and fill out the provided issue template.
 
 The information we are interested in includes:
@@ -87,7 +87,7 @@ community understand your suggestion :pencil: and find related suggestions
 Before creating enhancement suggestions, please check [this list](#before-submitting-an-enhancement-suggestion)
 as you might find out that you don't need to create one. When you are creating
 an enhancement suggestion, please [include as many details as possible](#how-do-i-submit-a-good-enhancement-suggestion).
-Fill in [the template](ISSUE_TEMPLATE/problem-to-raise.md), including the steps
+Fill in [the template](ISSUE_TEMPLATE/feature_request.yaml), including the steps
 that you imagine you would take if the feature you're requesting existed.
 
 #### Before Submitting An Enhancement Suggestion
@@ -101,7 +101,7 @@ information you would like to add.
 
 Enhancement suggestions are tracked as [GitHub issues](https://guides.github.com/features/issues/).
 
-Simply create an issue on the [GitHub Desktop issue tracker](https://github.com/desktop/desktop/issues/new?template=feature_request.md)
+Simply create an issue on the [GitHub Desktop issue tracker](https://github.com/desktop/desktop/issues/new?template=feature_request.yaml)
 and fill out the provided issue template.
 
 Some additional advice:


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #17829

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
-
When people want to contribute to the repository, they will go to the CONTRIBUTING.md file, but it seems that the hyperlinks have not been updated to match the names of the new templates.

1. Under https://github.com/desktop/desktop/blob/development/.github/CONTRIBUTING.md#how-do-i-submit-a-bug-report:
https://github.com/desktop/desktop/issues/new?template=bug_report.md should be https://github.com/desktop/desktop/issues/new?template=bug_report.yaml
2. Under https://github.com/desktop/desktop/blob/development/.github/CONTRIBUTING.md#suggesting-enhancements:
https://github.com/desktop/desktop/blob/development/.github/ISSUE_TEMPLATE/problem-to-raise.md should be https://github.com/desktop/desktop/blob/development/.github/ISSUE_TEMPLATE/feature_request.yaml
3. Under https://github.com/desktop/desktop/blob/development/.github/CONTRIBUTING.md#how-do-i-submit-an-enhancement-suggestion:
https://github.com/desktop/desktop/issues/new?template=feature_request.md should be https://github.com/desktop/desktop/issues/new?template=feature_request.yaml

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes
